### PR TITLE
Updated generate_annotations.py to fix csv read issue

### DIFF
--- a/contourusv/generate_annotation.py
+++ b/contourusv/generate_annotation.py
@@ -77,7 +77,8 @@ def load_csv_usv(file_name):
         Processed annotations with columns:
         ['begin_time', 'end_time']
     """
-    data = pd.read_csv(file_name, header=None, names=['begin_time', 'end_time'], usecols=[0, 1])
+    data = pd.read_csv(file_name, header=None, skiprows=1, names=[
+                'begin_time', 'end_time'], sep='\t', usecols=[1, 2])
     data['begin_time'] = data['begin_time'].astype(float)
     data['end_time'] = data['end_time'].astype(float)
     return data


### PR DESCRIPTION
This pull request addresses Issue #7 by updating line 80 in generate_annotations.py with the following:
`data = pd.read_csv(file_name, header=None, skiprows=1, names=['begin_time', 'end_time'], sep='\t', usecols=[1, 2])`

With this update, the issue, `pandas.errors.ParserError: Too many columns specified: expected 2 and found 1` does not occur anymore with the USCMed dataset's ground truth annotations.